### PR TITLE
Fix: nested object JSON serialization and add Jackson Kotlin module support

### DIFF
--- a/example/src/main/kotlin/io/github/lcomment/example/dto/request/ExampleRequest.kt
+++ b/example/src/main/kotlin/io/github/lcomment/example/dto/request/ExampleRequest.kt
@@ -18,9 +18,21 @@
 
 package io.github.lcomment.example.dto.request
 
+import io.github.lcomment.example.dto.response.ArrayResponse
+import io.github.lcomment.example.enums.ExampleEnum
 import jakarta.validation.constraints.NotBlank
 
 data class ExampleRequest(
     @field:NotBlank
     val example: String? = null,
-)
+    val arrayData: ArrayResponse = ArrayResponse(),
+    val enumData: ExampleEnum = ExampleEnum.EXAMPLE1,
+    val objectData: ObjectExample = ObjectExample(),
+) {
+
+    data class ObjectExample(
+        val value1: String = "value1",
+        val value2: Int = 1,
+        val value3: Boolean = true,
+    )
+}

--- a/example/src/test/kotlin/io/github/lcomment/example/controller/ApiSpec.kt
+++ b/example/src/test/kotlin/io/github/lcomment/example/controller/ApiSpec.kt
@@ -140,6 +140,13 @@ internal class ApiSpec {
 
                 requestField {
                     field("example", "example request", "example")
+                    field("arrayData.array1", "Array Data 1", request.arrayData.array1)
+                    field("arrayData.array2", "Array Data 2", request.arrayData.array2)
+                    field("arrayData.array3", "Array Data 3", request.arrayData.array3)
+                    field("enumData", "Enum Data", ExampleEnum.EXAMPLE1)
+                    field("objectData.value1", "Object Value 1", request.objectData.value1)
+                    field("objectData.value2", "Object Value 2", request.objectData.value2)
+                    field("objectData.value3", "Object Value 3", request.objectData.value3)
                 }
             }
     }
@@ -230,7 +237,15 @@ internal class ApiSpec {
             }
 
             requestField {
-                field("example", "example request", "example")
+                field("example", "Example Request", "example")
+                ignoredField("arrayData")
+                field("arrayData.array1", "Array Data 1", listOf("item1", "item2"))
+                field("arrayData.array2", "Array Data 2", setOf("item1", "item2"))
+                field("arrayData.array3", "Array Data 3", arrayOf("item1", "item2"))
+                field("enumData", "Enum Data", ExampleEnum.EXAMPLE1)
+                field("objectData.value1", "Object Value 1", "value1")
+                field("objectData.value2", "Object Value 2", 1)
+                field("objectData.value3", "Object Value 3", true)
             }
 
             responseField {

--- a/korest-docs-mockmvc/build.gradle.kts
+++ b/korest-docs-mockmvc/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(libs.jackson.databind)
     implementation(libs.jackson.datatype.jsr310)
     implementation(libs.jackson.core)
+    implementation(libs.jackson.module.kotlin)
 
     testImplementation(libs.kotest.junit)
     testImplementation(libs.kotest.assertions.core)

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -51,6 +51,7 @@ spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 
 # test
 spring-test = { module = "org.springframework:spring-test", version.ref = "spring6" }


### PR DESCRIPTION
## Summary

#17 

Fix nested object JSON serialization in MockMvc documentation generation by implementing proper dot notation to nested JSON conversion and adding Jackson Kotlin module support for proper Kotlin data class serialization.


## (Optional): Description

This PR addresses critical issues in API documentation generation:

1. Nested Object Serialization: Added toJsonString() and insert() functions to properly convert dot notation fields (e.g., arrayData.array1, objectData.value1) into correctly nested JSON structures instead of flat key-value pairs.
2. Jackson Kotlin Module: Added jackson-module-kotlin dependency to ensure proper serialization/deserialization of Kotlin data classes with default constructor parameters.
3. Enhanced Test Coverage: Extended ExampleRequest with complex nested objects, arrays, and enums to test the new serialization functionality.
4. GitHub Pages Deployment Fix: Updated artifact path from build to ./docs/build for correct documentation deployment.

Without these fixes, the generated API documentation would show incorrect JSON structures that don't match actual API request formats, potentially causing integration issues for API consumers.


## Checklist

- check base branch
- check lint and commit convention
- check test
